### PR TITLE
Add screenshot attachment on failure for Allure

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -35,6 +35,13 @@ current execution are included. The path is determined from the
 `allure.results.directory` system property when set, otherwise defaults to
 `target/allure-results`.
 
+### Failure Screenshots
+
+Whenever a test fails, a screenshot of the current page is captured automatically
+and attached to the corresponding entry in the Allure report using the failed
+test method's name. Screenshots are also saved under `attachments/screenshots`
+for local reference.
+
 ### Platform Configuration
 
 The framework uses the `platformType` property in

--- a/src/main/java/com/sure/utilities/TestNGListener.java
+++ b/src/main/java/com/sure/utilities/TestNGListener.java
@@ -1,7 +1,7 @@
 package com.sure.utilities;
 
 import com.sure.base.DriverManager;
-import io.qameta.allure.Attachment;
+import io.qameta.allure.Allure;
 import io.qameta.allure.Step;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.io.FileUtils;
@@ -13,6 +13,7 @@ import org.testng.ITestResult;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.ByteArrayInputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -70,7 +71,6 @@ public class TestNGListener implements ITestListener {
      * @param methodName    the failed test method
      * @return screenshot bytes or {@code null} when not available
      */
-    @Attachment(value = "Screenshot for the failure", type = "image/png", fileExtension = ".png")
     public byte[] attachScreenshotToAllure(DriverManager driverManager, String methodName) {
         screenshotBytes = null;
 
@@ -78,6 +78,11 @@ public class TestNGListener implements ITestListener {
             try {
                 // Capture screenshot as a byte array
                 screenshotBytes = takesscreenshot.getScreenshotAs(OutputType.BYTES);
+                byte[] finalBytes = screenshotBytes;
+                Allure.step("Capturing screenshot on failure", () -> {
+                    Allure.addAttachment(methodName + "-failure", "image/png",
+                            new ByteArrayInputStream(finalBytes), "png");
+                });
             } catch (Exception e) {
                 log.error("Failed to attach screenshot to Allure report for " + methodName, e);
             }


### PR DESCRIPTION
## Summary
- capture screenshots on failure using active Allure context
- document automatic screenshot capture for failed tests

## Testing
- `mvn -q -Dtest=LoginTest test` *(fails: Plugin resolution network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6880d9c3c778833085b4f2601d9963f9