### PR TITLE
Add screenshot attachment on failure for Allure

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -35,6 +35,15 @@ current execution are included. The path is determined from the
 `allure.results.directory` system property when set, otherwise defaults to
 `target/allure-results`.
 
+### Failure Screenshots
+
+Whenever a test fails, a screenshot of the current page is captured automatically
+and attached to the corresponding entry in the Allure report using the failed
+test method's name. Screenshots are also saved under `attachments/screenshots`
+for local reference. Each test class registers both the custom `TestNGListener`
+and the `AllureTestNg` listener so the failure screenshot is linked to the
+proper test case.
+
 ### Platform Configuration
 
 The framework uses the `platformType` property in

--- a/src/main/java/com/sure/utilities/TestNGListener.java
+++ b/src/main/java/com/sure/utilities/TestNGListener.java
@@ -1,7 +1,7 @@
 package com.sure.utilities;
 
 import com.sure.base.DriverManager;
-import io.qameta.allure.Attachment;
+import io.qameta.allure.Allure;
 import io.qameta.allure.Step;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.io.FileUtils;
@@ -13,6 +13,7 @@ import org.testng.ITestResult;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.ByteArrayInputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -70,7 +71,6 @@ public class TestNGListener implements ITestListener {
      * @param methodName    the failed test method
      * @return screenshot bytes or {@code null} when not available
      */
-    @Attachment(value = "Screenshot for the failure", type = "image/png", fileExtension = ".png")
     public byte[] attachScreenshotToAllure(DriverManager driverManager, String methodName) {
         screenshotBytes = null;
 
@@ -78,6 +78,10 @@ public class TestNGListener implements ITestListener {
             try {
                 // Capture screenshot as a byte array
                 screenshotBytes = takesscreenshot.getScreenshotAs(OutputType.BYTES);
+                byte[] finalBytes = screenshotBytes;
+                Allure.step("Capturing screenshot on failure", () ->
+                        Allure.addAttachment(methodName + "-failure", "image/png",
+                                new ByteArrayInputStream(finalBytes), "png"));
             } catch (Exception e) {
                 log.error("Failed to attach screenshot to Allure report for " + methodName, e);
             }

--- a/src/test/java/com/sure/tests/mobiletests/iostests/ResolutionDecisionTest.java
+++ b/src/test/java/com/sure/tests/mobiletests/iostests/ResolutionDecisionTest.java
@@ -18,9 +18,10 @@ import lombok.extern.log4j.Log4j2;
 import org.testng.Assert;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
+import io.qameta.allure.testng.AllureTestNg;
 
 @Log4j2
-@Listeners(com.sure.utilities.TestNGListener.class)
+@Listeners({AllureTestNg.class, com.sure.utilities.TestNGListener.class})
 public class ResolutionDecisionTest extends TestBase {
     private JsonPath jsonPath;
     private String token;

--- a/src/test/java/com/sure/tests/webtests/LoginTest.java
+++ b/src/test/java/com/sure/tests/webtests/LoginTest.java
@@ -5,10 +5,11 @@ import lombok.extern.log4j.Log4j2;
 import org.testng.Assert;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
+import io.qameta.allure.testng.AllureTestNg;
 
 
 @Log4j2
-@Listeners(com.sure.utilities.TestNGListener.class)
+@Listeners({AllureTestNg.class, com.sure.utilities.TestNGListener.class})
 public class LoginTest extends TestBase {
     @Test(priority = 1, description = "Given I am on Sign In Page, When The User Logged In Then User Name Appears")
     public void loginTest() {

--- a/src/test/java/com/sure/tests/webtests/ResolutionDecisionTest.java
+++ b/src/test/java/com/sure/tests/webtests/ResolutionDecisionTest.java
@@ -9,9 +9,10 @@ import lombok.extern.log4j.Log4j2;
 import org.testng.Assert;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
+import io.qameta.allure.testng.AllureTestNg;
 
 @Log4j2
-@Listeners(com.sure.utilities.TestNGListener.class)
+@Listeners({AllureTestNg.class, com.sure.utilities.TestNGListener.class})
 public class ResolutionDecisionTest extends TestBase {
     String email, password;
 


### PR DESCRIPTION
## Summary
- capture screenshots on failure using active Allure context
- document automatic screenshot capture for failed tests
- register Allure listener on test classes

## Testing
- `mvn -q -Dtest=LoginTest test` *(fails: Plugin resolution network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6880d9c3c778833085b4f2601d9963f9